### PR TITLE
chore: cleaning up transitive transforms

### DIFF
--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -15,7 +15,26 @@ var Color           = require('tinycolor2'),
     _               = require('lodash'),
     path            = require('path'),
     convertToBase64 = require('../utils/convertToBase64'),
+    usesReference   = require('../utils/references/usesReference'),
     UNICODE_PATTERN = /&#x([^;]+);/g;
+
+// higher-order function that applies a value transform
+// if it is not a reference to another property. We want to do that
+// because most transforms mutate the value in ways that can have
+// unintended consequences when done multiple times.
+// For example some transforms wrap the value in quotes, if we apply that
+// transform multiple times you would get a value like """hello""".
+function transformUnlessReference(fn) {
+  return function(prop, ...args) {
+    // If the property doesn't have an `original` attribute
+    const { original = false } = prop;
+    // If the original value was a reference, don't apply the transform and just
+    // return the value.
+    if (usesReference(original.value)) return prop.value;
+    // else run the transform as normal
+    return fn(prop, ...args);
+  }
+}
 
 function isColor(prop) {
   return prop.attributes.category === 'color';
@@ -40,12 +59,20 @@ function isAsset(prop) {
 	return prop.attributes.category === 'asset';
 }
 
+function isContent(prop) {
+	return prop.attributes.category === 'content';
+}
+
 function wrapValueWith(character, prop) {
 	return `${character}${prop.value}${character}`;
 }
 
 function wrapValueWithDoubleQuote(prop) {
 	return wrapValueWith('"', prop);
+}
+
+function throwSizeError(name, value, unitType) {
+  throw `Invalid Number: '${name}: ${value}' is not a valid number, cannot transform to '${unitType}' \n`;
 }
 /**
  * @namespace Transforms
@@ -71,13 +98,16 @@ module.exports = {
   'attribute/cti': {
     type: 'attribute',
     transformer: function(prop) {
-      return {
-        category: prop.path[0],
-        type:     prop.path[1],
-        item:     prop.path[2],
-        subitem:  prop.path[3],
-        state:    prop.path[4]
+
+      const attrNames = ['category', 'type', 'item', 'subitem', 'state'];
+      const originalAttrs = prop.attributes || {};
+      const generatedAttrs =  {}
+
+      for(let i=0; i<prop.path.length && i<attrNames.length; i++) {
+        generatedAttrs[attrNames[i]] = prop.path[i];
       }
+
+      return Object.assign(generatedAttrs, originalAttrs);
     }
   },
 
@@ -287,6 +317,53 @@ module.exports = {
     }
   },
 
+    /**
+   * Transforms the value into an HSL string or HSLA if alpha is present. Better browser support than color/hsl-4
+   *
+   * ```js
+   * // Matches: prop.attributes.category === 'color'
+   * // Returns:
+   * "hsl(174, 100%, 29%)"
+   * "hsl(174, 100%, 29%, .5)"
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'color/hsl': {
+    type: 'value',
+    matcher: isColor,
+    transformer: function (prop) {
+      return Color(prop.value).toHslString();
+    }
+  },
+
+    /**
+   * Transforms the value into an HSL string, using fourth argument if alpha is present.
+   *
+   * ```js
+   * // Matches: prop.attributes.category === 'color'
+   * // Returns:
+   * "hsl(174 100% 29%)"
+   * "hsl(174 100% 29% / .5)"
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'color/hsl-4': {
+    type: 'value',
+    matcher: isColor,
+    transformer: function (prop) {
+      var color = Color(prop.value);
+      var o = color.toHsl()
+      var vals = `${Math.round(o.h)} ${Math.round(o.s * 100)}% ${Math.round(o.l * 100)}%`
+      if (color.getAlpha() === 1) {
+        return `hsl(${vals})`
+      } else {
+        return `hsl(${vals} / ${o.a})`
+      }
+    }
+  },
+
   /**
    * Transforms the value into an 6-digit hex string
    *
@@ -359,13 +436,13 @@ module.exports = {
   'color/UIColor': {
     type: 'value',
     matcher: isColor,
-    transformer: function (prop) {
+    transformer: transformUnlessReference(function (prop) {
       var rgb = Color(prop.value).toRgb();
       return '[UIColor colorWithRed:' + (rgb.r/255).toFixed(3) + 'f' +
              ' green:' + (rgb.g/255).toFixed(3) + 'f' +
              ' blue:' + (rgb.b/255).toFixed(3) + 'f' +
              ' alpha:' + rgb.a.toFixed(3) + 'f]';
-    }
+    })
   },
 
     /**
@@ -382,13 +459,13 @@ module.exports = {
   'color/UIColorSwift': {
     type: 'value',
     matcher: isColor,
-    transformer: function (prop) {
+    transformer: transformUnlessReference(function (prop) {
       const { r, g, b, a } = Color(prop.value).toRgb();
       const rFixed = (r / 255.0).toFixed(3);
       const gFixed = (g / 255.0).toFixed(3);
       const bFixed = (b / 255.0).toFixed(3);
       return `UIColor(red: ${rFixed}, green: ${gFixed}, blue: ${bFixed}, alpha:${a})`;
-    }
+    })
   },
 
   /**
@@ -406,14 +483,14 @@ module.exports = {
   'color/css': {
     type: 'value',
     matcher: isColor,
-    transformer: function (prop) {
+    transformer: transformUnlessReference(function (prop) {
       var color = Color(prop.value);
       if (color.getAlpha() === 1) {
         return color.toHexString();
       } else {
         return color.toRgbString();
       }
-    }
+    })
   },
 
   /**
@@ -437,15 +514,15 @@ module.exports = {
   'color/sketch': {
     type: 'value',
     matcher: (prop) => prop.attributes.category === 'color',
-    transformer: function(prop) {
+    transformer: transformUnlessReference(function(prop) {
       let color = Color(prop.original.value).toRgb();
       return {
-        red: (color.r / 255).toFixed(2),
-        green: (color.g / 255).toFixed(2),
-        blue: (color.b / 255).toFixed(2),
+        red: (color.r / 255).toFixed(5),
+        green: (color.g / 255).toFixed(5),
+        blue: (color.b / 255).toFixed(5),
         alpha: color.a
       }
-    }
+    })
   },
 
   /**
@@ -462,9 +539,11 @@ module.exports = {
   'size/sp': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function(prop) {
-      return parseFloat(prop.value, 10).toFixed(2) + 'sp';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'sp');
+      return val.toFixed(2) + 'sp';
+    })
   },
 
   /**
@@ -481,9 +560,11 @@ module.exports = {
   'size/dp': {
     type: 'value',
     matcher: isNotFontSize,
-    transformer: function(prop) {
-      return parseFloat(prop.value, 10).toFixed(2) + 'dp';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'dp');
+      return val.toFixed(2) + 'dp';
+    })
   },
 
   /**
@@ -500,9 +581,11 @@ module.exports = {
   'size/remToSp': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'sp';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'sp');
+      return (val * 16).toFixed(2) + 'sp';
+    })
   },
 
 
@@ -520,9 +603,11 @@ module.exports = {
   'size/remToDp': {
     type: 'value',
     matcher: isNotFontSize,
-    transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'dp';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'dp');
+      return (val * 16).toFixed(2) + 'dp';
+    })
   },
 
 
@@ -540,9 +625,11 @@ module.exports = {
   'size/px': {
     type: 'value',
     matcher: isSize,
-    transformer: function(prop) {
-      return parseFloat(prop.value, 10) + 'px';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'px');
+      return val + 'px';
+    })
   },
 
   /**
@@ -559,9 +646,11 @@ module.exports = {
   'size/rem': {
     type: 'value',
     matcher: isSize,
-    transformer: function(prop) {
-      return parseFloat(prop.value, 10) + 'rem';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'rem');
+      return val + 'rem';
+    })
   },
 
   /**
@@ -578,9 +667,11 @@ module.exports = {
   'size/remToPt': {
     type: 'value',
     matcher: isSize,
-    transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'f';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'pt');
+      return (val * 16).toFixed(2) + 'f';
+    })
   },
 
   /**
@@ -596,9 +687,11 @@ module.exports = {
   'size/swift/remToCGFloat': {
     type: 'value',
     matcher: isSize,
-    transformer: function(prop) {
-      return `CGFloat(${(parseFloat(prop.value, 10) * 16).toFixed(2)})`;
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'CGFloat');
+      return `CGFloat(${(val * 16).toFixed(2)})`;
+    })
   },
 
   /**
@@ -615,9 +708,11 @@ module.exports = {
   'size/remToPx': {
     type: 'value',
     matcher: isSize,
-    transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(0) + 'px';
-    }
+    transformer: transformUnlessReference(function(prop) {
+      const val = parseFloat(prop.value);
+      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'px');
+      return (val * 16).toFixed(0) + 'px';
+    })
   },
 
   /**
@@ -636,11 +731,11 @@ module.exports = {
     matcher: function (prop) {
       return prop.attributes.category === 'content' && prop.attributes.type === 'icon';
     },
-    transformer: function (prop) {
+    transformer: transformUnlessReference(function (prop) {
       return prop.value.replace(UNICODE_PATTERN, function (match, variable) {
         return "'\\" + variable + "'";
       });
-    }
+    })
   },
 
   /**
@@ -656,12 +751,10 @@ module.exports = {
    */
   'content/quote': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'content';
-    },
-    transformer: function(prop) {
+    matcher: isContent,
+    transformer: transformUnlessReference(function(prop) {
       return  wrapValueWith('\'', prop);
-    }
+    })
   },
 
   /**
@@ -677,12 +770,10 @@ module.exports = {
    */
   'content/objC/literal': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'content';
-    },
-    transformer: function(prop) {
+    matcher: isContent,
+    transformer: transformUnlessReference(function(prop) {
       return '@' + wrapValueWithDoubleQuote(prop);
-    }
+    })
   },
 
   /**
@@ -698,10 +789,8 @@ module.exports = {
    */
   'content/swift/literal': {
     type: 'value',
-    matcher: function(prop) {
-      return prop.attributes.category === 'content';
-    },
-    transformer: wrapValueWithDoubleQuote
+    matcher: isContent,
+    transformer: transformUnlessReference(wrapValueWithDoubleQuote)
   },
 
   /**
@@ -719,9 +808,9 @@ module.exports = {
     matcher: function(prop) {
       return prop.attributes.category === 'font';
     },
-    transformer: function(prop) {
+    transformer: transformUnlessReference(function(prop) {
       return '@' + wrapValueWithDoubleQuote(prop);
-    }
+    })
   },
 
   /**
@@ -739,7 +828,7 @@ module.exports = {
     matcher: function(prop) {
       return prop.attributes.category === 'font';
     },
-    transformer: wrapValueWithDoubleQuote
+    transformer: transformUnlessReference(wrapValueWithDoubleQuote)
   },
 
 
@@ -759,9 +848,9 @@ module.exports = {
     matcher: function(prop) {
       return prop.attributes.category === 'time';
     },
-    transformer: function(prop) {
+    transformer: transformUnlessReference(function(prop) {
       return (parseFloat(prop.value) / 1000).toFixed(2) + 's';
-    }
+    })
   },
 
   /**
@@ -778,9 +867,9 @@ module.exports = {
   'asset/base64': {
     type: 'value',
     matcher: isAsset,
-    transformer: function(prop) {
+    transformer: transformUnlessReference(function(prop) {
       return convertToBase64(prop.value);
-    }
+    })
   },
 
   /**
@@ -797,9 +886,9 @@ module.exports = {
   'asset/path': {
     type: 'value',
     matcher: isAsset,
-    transformer: function(prop) {
+    transformer: transformUnlessReference(function(prop) {
       return path.join(process.cwd(), prop.value);
-    }
+    })
   },
 
   /**
@@ -815,9 +904,9 @@ module.exports = {
   'asset/objC/literal': {
     type: 'value',
     matcher: isAsset,
-    transformer: function(prop) {
+    transformer: transformUnlessReference(function(prop) {
       return '@' + wrapValueWithDoubleQuote(prop);
-    }
+    })
   },
 
   /**
@@ -833,6 +922,95 @@ module.exports = {
   'asset/swift/literal': {
     type: 'value',
     matcher: isAsset,
-    transformer: wrapValueWithDoubleQuote
+    transformer: transformUnlessReference(wrapValueWithDoubleQuote)
+  },
+
+
+  /**
+   * Transforms the value into a Flutter Color object using 8-digit hex with the alpha chanel on start
+   *  ```js
+   *  // Matches: prop.attributes.category === 'color'
+   *  // Returns:
+   *  Color(0xFF00FF5F)
+   *  ```
+   *  @memberof Transforms
+   *
+   */
+  'color/hex8flutter': {
+    type: 'value',
+    matcher: isColor,
+    transformer: transformUnlessReference(function (prop) {
+        var str = Color(prop.value).toHex8().toUpperCase();
+        return `Color(0x${str.slice(6)}${str.slice(0,6)})`;
+    })
+  },
+
+  /**
+   * Wraps the value in a double-quoted string to make a string literal.
+   *
+   * ```dart
+   * // Matches: prop.attributes.category === 'content'
+   * // Returns: "string"
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'content/flutter/literal': {
+    type: 'value',
+    matcher: isContent,
+    transformer: transformUnlessReference(wrapValueWithDoubleQuote)
+  },
+
+  /**
+   * Wraps the value in a double-quoted string to make a string literal.
+   *
+   * ```dart
+   * // Matches: prop.attributes.category === 'asset'
+   * // Returns: "string"
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'asset/flutter/literal': {
+    type: 'value',
+    matcher: isAsset,
+    transformer: transformUnlessReference(wrapValueWithDoubleQuote)
+  },
+
+  /**
+ * Wraps the value in a double-quoted string to make a string literal.
+ *
+ * ```dart
+ * // Matches: prop.attributes.category === 'font'
+ * // Returns: "string"
+ * ```
+ *
+ * @memberof Transforms
+ */
+  'font/flutter/literal': {
+    type: 'value',
+    matcher: function (prop) {
+      return prop.attributes.category === 'font';
+    },
+    transformer: transformUnlessReference(wrapValueWithDoubleQuote)
+  },
+
+  /**
+   * Scales the number by 16 to get to points for Flutter
+   *
+   * ```dart
+   * // Matches: prop.attributes.category === 'size'
+   * // Returns: 16.00
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'size/flutter/remToDouble': {
+    type: 'value',
+    matcher: isSize,
+    transformer: transformUnlessReference(function (prop) {
+      return (parseFloat(prop.value, 10) * 16).toFixed(2);
+    })
   }
+
 };

--- a/lib/exportPlatform.js
+++ b/lib/exportPlatform.js
@@ -54,9 +54,9 @@ function exportPlatform(platform) {
   };
 
   let loopCount = 0;
+  let finished;
 
-  // eslint-disable-next-line no-constant-condition
-  while(true) {
+  while(typeof finished === "undefined") {
     // We keep up transforming and resolving until all props are resolved
     // and every defined transformation was executed. Remember: transformations
     // can only be executed, if the value to be transformed, has no references
@@ -86,12 +86,9 @@ function exportPlatform(platform) {
     //
     // As you can see 'color.background.button.primary.hover' is a variation
     // of 'color.background.button.primary.base' which is a variation of
-    // 'color.base.green'. This transitive dependencies are solved by running
-    // this loop.
+    // 'color.base.green'. These transitive references are solved by running
+    // this loop until all properties are transformed and resolved.
     loopCount++;
-
-    const transformationsCountBefore = transformedPropRefs.length;
-    const deferredPropValueTransformsCountBefore = deferredPropValueTransforms.length;
 
     // We need to transform the object before we resolve the
     // variable names because if a value contains concatenated
@@ -102,16 +99,11 @@ function exportPlatform(platform) {
 
     // referenced values, that have not (yet) been transformed should be excluded from resolving
     const ignorePathsToResolve = deferredPropValueTransforms.map(p => getName([p, 'value']));
-
     exportableResult = resolveObject(transformed, {ignorePaths: ignorePathsToResolve});
 
-    // nothing transformed and deferred props transforms has not changed? -> ready
-    if (
-      loopCount > 1 &&
-      transformedPropRefs.length === transformationsCountBefore &&
-      deferredPropValueTransforms.length === deferredPropValueTransformsCountBefore
-    ) {
-      break;
+    // nothing left to transform -> ready
+    if (deferredPropValueTransforms.length === 0) {
+      finished = true;
     }
   }
 

--- a/lib/transform/object.js
+++ b/lib/transform/object.js
@@ -42,50 +42,59 @@ function transformObject(obj, options, transformationContext = {}, path, transfo
     }
 
     path.push(name);
-
-    const pathName = getName(path);
     const objProp = obj[name];
-    const alreadyTransformed = transformedPropRefs.indexOf(pathName) !== -1;
     const isPlainObject = _.isPlainObject(objProp);
-    const transformationNeeded = !alreadyTransformed && isPlainObject;
-
-    if (!transformationNeeded) {
-      transformedObj[name] = objProp;
-      path.pop();
-      continue;
-    }
 
     // is the objProp a style property?
     // {
     //   value: "#ababab"
     //   ...
     // }
-    if ('value' in objProp) {
+    if (isPlainObject && 'value' in objProp) {
+      const pathName = getName(path);
+      const alreadyTransformed = transformedPropRefs.indexOf(pathName) !== -1;
+
+      // If the property is already transformed, just pass assign it to the
+      // transformed object and move on.
+      if (alreadyTransformed) {
+        transformedObj[name] = objProp;
+        path.pop();
+        continue;
+      }
+
+      // Note: propertySetup won't re-run if property has already been setup
+      // it is safe to run this multiple times on the same property.
       const setupProperty = propertySetup(objProp, name, path);
 
+      // If property has a reference, defer its transformations until later
       if (usesValueReference(setupProperty.value, options)) {
-        deferredPropValueTransforms.push(pathName);
+        // If property path isn't in the deferred array, add it now.
+        if (deferredPropValueTransforms.indexOf(pathName) === -1) {
+          deferredPropValueTransforms.push(pathName);
+        }
+
         transformedObj[name] = setupProperty;
         path.pop();
         continue;
       }
 
-      const transformedObjectValue = transformProperty(setupProperty, options);
+      // If we got here, the property hasn't been transformed yet and
+      // does not use a value reference. Transform the property now and assign it.
+      transformedObj[name] = transformProperty(setupProperty, options);
+      // Remove the property path from the deferred transform list
       _.pull(deferredPropValueTransforms, pathName);
-
-      // transformed anything?
-      if (setupProperty.value !== transformedObjectValue.value) {
-        transformedPropRefs.push(pathName);
-      }
-
-      transformedObj[name] = transformedObjectValue;
-      path.pop();
-      continue;
+      // Add the property path to the transformed list so we don't transform it again.
+      transformedPropRefs.push(pathName);
+    } else if (isPlainObject) {
+      // objProp is not a token -> go deeper down the object tree
+      transformedObj[name] = transformObject(objProp, options, transformationContext, path, transformedObj[name]);
+    } else {
+      // objProp is not a token or an object then it is some other data in the
+      // object we should just copy over. There might be metadata
+      // like documentation in the object that is not part of a token/property.
+      transformedObj[name] = objProp;
     }
 
-    // objectValue is not a property -> go deeper down the object tree
-    transformedObj[name] = {};
-    transformObject(objProp, options, transformationContext, path, transformedObj[name]);
     path.pop();
   }
 


### PR DESCRIPTION
*Issue #, if available:* #208 and pull request #371

*Description of changes:* Rather than making a bunch of comments on your pull request, it was easier to propose changes on your branch. 

1. Changed the while loop in exportPlatform so it doesn't run too many times. Previously the loop was running 1 too many times. 
1. Fixed an issue that would cause an infinite loop in the transformObject step. The dictionary object can have other data in it like documentation. Calling a for..in loop on an attribute that is just a string caused an infinite loop.
1. Fixed all the built-in transforms to only run on non-reference values because most of the operations were destructive. For example some size transforms multiplied the value by 16 to go from REM to DP and would have run N+1 times where N is the length of the reference chain. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
